### PR TITLE
♻️ refactor: base component 타입스크립트 적용 및 스토리북 리팩토리

### DIFF
--- a/src/components/base/Avatar/index.tsx
+++ b/src/components/base/Avatar/index.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react'
 import type { AvatarProps } from './types'
 import AvatarWrapper from './styled'
 import Image from '@base/Image'
-import { NO_IMAGE_USER } from '@constants'
+import { NO_IMAGE_USER_IMG } from '@constants'
 
 const Avatar = ({
   src,
@@ -17,8 +17,8 @@ const Avatar = ({
         border={false}
         height={height}
         mode="cover"
-        placeholder={NO_IMAGE_USER}
-        src={src || NO_IMAGE_USER}
+        placeholder={NO_IMAGE_USER_IMG}
+        src={src || NO_IMAGE_USER_IMG}
         type="user"
         width={width}
       />

--- a/src/components/base/Avatar/index.tsx
+++ b/src/components/base/Avatar/index.tsx
@@ -17,9 +17,8 @@ const Avatar = ({
         border={false}
         height={height}
         mode="cover"
-        placeholder={NO_IMAGE_USER_IMG}
+        placeholder="user"
         src={src || NO_IMAGE_USER_IMG}
-        type="user"
         width={width}
       />
     </AvatarWrapper>

--- a/src/components/base/Avatar/styled.tsx
+++ b/src/components/base/Avatar/styled.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import type { StyledAvatarWrapperProps } from './types'
-import { BORDER } from '@constants'
+import { MEDIUM_GRAY } from '@constants'
 
 const AvatarWrapper = styled.div<StyledAvatarWrapperProps>`
   display: inline-block;
@@ -8,7 +8,7 @@ const AvatarWrapper = styled.div<StyledAvatarWrapperProps>`
     typeof width === 'string' ? width : `${width}px`};
   height: ${({ height }): string =>
     typeof height === 'string' ? height : `${height}px`};
-  border: 1px solid ${BORDER};
+  border: 1px solid ${MEDIUM_GRAY};
   border-radius: 100%;
   overflow: hidden;
 `

--- a/src/components/base/Avatar/types.ts
+++ b/src/components/base/Avatar/types.ts
@@ -1,7 +1,6 @@
 import type { ImgHTMLAttributes } from 'react'
 
 interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
-  src?: string
   width?: number | string
   height?: number | string
 }

--- a/src/components/base/Button/index.tsx
+++ b/src/components/base/Button/index.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react'
+import StyledButton from './styled'
+import type { ButtonProps } from './types'
+
+const Button = ({
+  type = 'button',
+  width = '215px',
+  height = '50px',
+  theme = 'primary',
+  fontSize = 'SM',
+  strong = true,
+  ...props
+}: ButtonProps): ReactElement => {
+  return (
+    <StyledButton
+      disabled={theme === 'disabled'}
+      fontSize={fontSize}
+      height={height}
+      strong={strong}
+      theme={theme}
+      type={type}
+      width={width}
+      {...props}
+    />
+  )
+}
+
+export default Button

--- a/src/components/base/Button/styled.tsx
+++ b/src/components/base/Button/styled.tsx
@@ -12,7 +12,7 @@ import {
 } from '@constants'
 import type { ButtonTheme, styledButtonProps } from './types'
 
-const converThemeToStyle = (theme: ButtonTheme): string => {
+const applyThemeStyle = (theme: ButtonTheme): string => {
   switch (theme) {
     case 'disabled':
       return `
@@ -64,7 +64,7 @@ const StyledButton = styled.button<styledButtonProps>`
   border-radius: 3px;
   font-size: ${({ fontSize = 'SM' }): string => FONT_SIZE[fontSize]};
   font-weight: ${({ strong }): number => (strong ? 600 : 400)};
-  ${({ theme }): string => converThemeToStyle(theme)}
+  ${({ theme }): string => applyThemeStyle(theme)};
 `
 
 export default StyledButton

--- a/src/components/base/Button/styled.tsx
+++ b/src/components/base/Button/styled.tsx
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled'
+import {
+  FONT_SIZE,
+  KAKAO,
+  PRIMARY,
+  BLACK,
+  WHITE,
+  DARK_GRAY,
+  WHITE_GRAY,
+  MEDIUM_GRAY,
+  FONT_KAKAO
+} from '@constants'
+import type { ButtonTheme, styledButtonProps } from './types'
+
+const converThemeToStyle = (theme: ButtonTheme): string => {
+  switch (theme) {
+    case 'disabled':
+      return `
+        cursor: default;
+        color: ${WHITE};
+        border: none;
+        background-color: ${MEDIUM_GRAY};
+      `
+    case 'kakao':
+      return `
+        color: ${FONT_KAKAO};
+        border: none;
+        background-color: ${KAKAO};
+      `
+    case 'line-primary':
+      return `
+        color: ${PRIMARY};
+        border: 1px solid;
+        background-color: ${WHITE};
+      `
+    case 'line-black':
+      return `
+        color: ${BLACK};
+        border: 1px solid;
+        background-color: ${WHITE};
+      `
+    case 'line-gray':
+      return `
+        color: ${DARK_GRAY};
+        border: 1px solid ${WHITE_GRAY};
+        background-color: ${WHITE};
+      `
+    default:
+      return `
+        color: ${WHITE};
+        border: none;
+        background-color: ${PRIMARY};
+      `
+  }
+}
+
+const StyledButton = styled.button<styledButtonProps>`
+  cursor: pointer;
+  user-select: none;
+  width: ${({ width }): string =>
+    typeof width === 'string' ? width : `${width}px`};
+  height: ${({ height }): string =>
+    typeof height === 'string' ? height : `${height}px`};
+  border-radius: 3px;
+  font-size: ${({ fontSize = 'SM' }): string => FONT_SIZE[fontSize]};
+  font-weight: ${({ strong }): number => (strong ? 600 : 400)};
+  ${({ theme }): string => converThemeToStyle(theme)}
+`
+
+export default StyledButton

--- a/src/components/base/Button/types.ts
+++ b/src/components/base/Button/types.ts
@@ -1,0 +1,28 @@
+import type { ButtonHTMLAttributes } from 'react'
+import type { FONT_SIZE } from '@constants'
+
+type ButtonType = 'button' | 'submit'
+type ButtonTheme =
+  | 'primary'
+  | 'disabled'
+  | 'kakao'
+  | 'line-primary'
+  | 'line-black'
+  | 'line-gray'
+type ButtonFontSizeKeys = keyof typeof FONT_SIZE
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  type: ButtonType
+  width?: string | number
+  height?: string | number
+  theme: ButtonTheme
+  fontSize?: ButtonFontSizeKeys
+  strong?: boolean
+}
+
+type styledButtonProps = Pick<
+  ButtonProps,
+  'theme' | 'width' | 'height' | 'fontSize' | 'strong'
+>
+
+export type { ButtonProps, ButtonTheme, styledButtonProps }

--- a/src/components/base/Dialog/index.tsx
+++ b/src/components/base/Dialog/index.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from 'react'
+import StyledDialogWrapper from './styled'
+import Link from 'next/dist/client/link'
+import type { DialogProps } from './types'
+
+const Dialog = ({
+  dialogRef,
+  width = '90px',
+  dialogItemList,
+  visible = false,
+  ...props
+}: DialogProps<HTMLUListElement>): ReactElement => (
+  <StyledDialogWrapper
+    ref={dialogRef}
+    dialogItemList={dialogItemList}
+    visible={visible}
+    width={width}
+    {...props}>
+    {dialogItemList?.map(({ href, text, onClick }, idx) => (
+      <li key={idx}>
+        {href ? (
+          <Link href={href}>
+            <a onClick={onClick}>{text}</a>
+          </Link>
+        ) : (
+          <span onClick={onClick}>{text}</span>
+        )}
+      </li>
+    ))}
+  </StyledDialogWrapper>
+)
+
+export default Dialog

--- a/src/components/base/Dialog/styled.tsx
+++ b/src/components/base/Dialog/styled.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled'
+import type { styledDialogProps, dialogItemListType } from './types'
+import { FONT_SIZE, BLACK, WHITE, WHITE_GRAY } from '@constants'
+
+const applyStyleDialogItem = (dialogItemList: dialogItemListType): string => {
+  if (dialogItemList.length > 2) {
+    return `&:not(:first-of-type, :last-child) {
+      padding: 20px 0;
+    }`
+  }
+
+  if (dialogItemList.length === 2) {
+    return `&:last-child {
+      padding-top: 20px;
+    }`
+  }
+
+  return ''
+}
+
+const StyledDialogWrapper = styled.ul<styledDialogProps>`
+  display: ${({ visible }): string => (visible ? 'block' : 'none')};
+  position: absolute;
+  width: ${({ width }): string =>
+    typeof width === 'string' ? width : `${width}px`};
+  padding: 20px;
+  list-style: none;
+  border: 1px solid ${WHITE_GRAY};
+  border-radius: 5px;
+  background-color: ${WHITE};
+
+  li {
+    text-align: center;
+    ${({ dialogItemList }): string => applyStyleDialogItem(dialogItemList)}
+
+    span {
+      cursor: pointer;
+      font-size: ${FONT_SIZE.NORMAL};
+    }
+
+    a {
+      text-decoration: none;
+      color: ${BLACK};
+      font-size: ${FONT_SIZE.NORMAL};
+    }
+  }
+`
+
+export default StyledDialogWrapper

--- a/src/components/base/Dialog/styled.tsx
+++ b/src/components/base/Dialog/styled.tsx
@@ -1,25 +1,11 @@
 import styled from '@emotion/styled'
-import type { styledDialogProps, dialogItemListType } from './types'
+import type { styledDialogProps } from './types'
 import { FONT_SIZE, BLACK, WHITE, WHITE_GRAY } from '@constants'
 
-const applyStyleDialogItem = (dialogItemList: dialogItemListType): string => {
-  if (dialogItemList.length > 2) {
-    return `&:not(:first-of-type, :last-child) {
-      padding: 20px 0;
-    }`
-  }
-
-  if (dialogItemList.length === 2) {
-    return `&:last-child {
-      padding-top: 20px;
-    }`
-  }
-
-  return ''
-}
-
 const StyledDialogWrapper = styled.ul<styledDialogProps>`
-  display: ${({ visible }): string => (visible ? 'block' : 'none')};
+  display: ${({ visible }): string => (visible ? 'flex' : 'none')};
+  gap: 20px;
+  flex-direction: column;
   position: absolute;
   width: ${({ width }): string =>
     typeof width === 'string' ? width : `${width}px`};
@@ -31,7 +17,6 @@ const StyledDialogWrapper = styled.ul<styledDialogProps>`
 
   li {
     text-align: center;
-    ${({ dialogItemList }): string => applyStyleDialogItem(dialogItemList)}
 
     span {
       cursor: pointer;

--- a/src/components/base/Dialog/types.ts
+++ b/src/components/base/Dialog/types.ts
@@ -1,0 +1,23 @@
+import type { HTMLAttributes, RefObject } from 'react'
+
+interface IdialogItem {
+  text: string
+  href?: string
+  onClick?(e?: any): void
+}
+
+interface DialogProps<RefType> extends HTMLAttributes<HTMLUListElement> {
+  dialogRef?: RefObject<RefType>
+  width?: string | number
+  dialogItemList: IdialogItem[]
+  visible: boolean
+}
+
+type dialogItemListType = IdialogItem[]
+
+type styledDialogProps = Pick<
+  DialogProps<HTMLUListElement>,
+  'visible' | 'width' | 'dialogItemList'
+>
+
+export type { DialogProps, styledDialogProps, dialogItemListType }

--- a/src/components/base/Dialog/types.ts
+++ b/src/components/base/Dialog/types.ts
@@ -7,7 +7,7 @@ interface IdialogItem {
 }
 
 interface DialogProps<RefType> extends HTMLAttributes<HTMLUListElement> {
-  dialogRef?: RefObject<RefType>
+  dialogRef: RefObject<RefType> | null
   width?: string | number
   dialogItemList: IdialogItem[]
   visible: boolean

--- a/src/components/base/Dialog/types.ts
+++ b/src/components/base/Dialog/types.ts
@@ -13,11 +13,9 @@ interface DialogProps<RefType> extends HTMLAttributes<HTMLUListElement> {
   visible: boolean
 }
 
-type dialogItemListType = IdialogItem[]
-
 type styledDialogProps = Pick<
   DialogProps<HTMLUListElement>,
   'visible' | 'width' | 'dialogItemList'
 >
 
-export type { DialogProps, styledDialogProps, dialogItemListType }
+export type { DialogProps, styledDialogProps }

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -3,11 +3,11 @@ import type { ImageProps } from './types'
 import { useRef, useEffect, useState } from 'react'
 import StyledImg from './styled'
 import {
-  NO_IMAGE_USER,
-  NO_IMAGE_SQUARE,
-  NO_IMAGE_PRODUCT,
-  NO_IMAGE_RECTANGLE_W,
-  NO_IMAGE_RECTANGLE_H
+  NO_IMAGE_USER_IMG,
+  NO_IMAGE_SQUARE_IMG,
+  NO_IMAGE_PRODUCT_IMG,
+  NO_IMAGE_RECTANGLE_W_IMG,
+  NO_IMAGE_RECTANGLE_H_IMG
 } from '@constants'
 
 const LOAD_IMG_EVENT = 'loadImage'
@@ -47,19 +47,19 @@ const Image = ({
   const handleError = (e: SyntheticEvent<HTMLImageElement>): void => {
     switch (type) {
       case 'user':
-        e.currentTarget.src = NO_IMAGE_USER
+        e.currentTarget.src = NO_IMAGE_USER_IMG
         break
       case 'product':
-        e.currentTarget.src = NO_IMAGE_PRODUCT
+        e.currentTarget.src = NO_IMAGE_PRODUCT_IMG
         break
       case 'square':
-        e.currentTarget.src = NO_IMAGE_SQUARE
+        e.currentTarget.src = NO_IMAGE_SQUARE_IMG
         break
       case 'rectangleW':
-        e.currentTarget.src = NO_IMAGE_RECTANGLE_W
+        e.currentTarget.src = NO_IMAGE_RECTANGLE_W_IMG
         break
       case 'rectangleH':
-        e.currentTarget.src = NO_IMAGE_RECTANGLE_H
+        e.currentTarget.src = NO_IMAGE_RECTANGLE_H_IMG
         break
     }
   }

--- a/src/components/base/Image/styled.ts
+++ b/src/components/base/Image/styled.ts
@@ -1,4 +1,4 @@
-import { BORDER } from '@constants'
+import { MEDIUM_GRAY } from '@constants'
 import styled from '@emotion/styled'
 import type { StyledImgProps } from './types'
 
@@ -9,6 +9,7 @@ const StyledImg = styled.img<StyledImgProps>`
     typeof width === 'string' ? width : `${width}px`};
   height: ${({ height }): string =>
     typeof height === 'string' ? height : `${height}px`};
-  border: ${({ border }): string => (border ? `1px solid ${BORDER}` : 'none')};
+  border: ${({ border }): string =>
+    border ? `1px solid ${MEDIUM_GRAY}` : 'none'};
 `
 export default StyledImg

--- a/src/components/base/Image/types.ts
+++ b/src/components/base/Image/types.ts
@@ -1,17 +1,21 @@
 import type { ImgHTMLAttributes } from 'react'
 
 type ImageMode = 'cover' | 'fill' | 'contain'
-type ImageType = 'user' | 'product' | 'square' | 'rectangleW' | 'rectangleH'
+type ImagePlaceholerType =
+  | 'user'
+  | 'product'
+  | 'square'
+  | 'rectangleW'
+  | 'rectangleH'
 
 interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   lazy?: boolean
   width?: number | string
   height?: number | string
   mode: ImageMode
-  type: ImageType
   block?: boolean
   border?: boolean
-  placeholder?: string
+  placeholder?: ImagePlaceholerType
   threshold?: number
 }
 
@@ -20,4 +24,4 @@ type StyledImgProps = Pick<
   'width' | 'height' | 'mode' | 'block' | 'border'
 >
 
-export type { ImageMode, ImageType, ImageProps, StyledImgProps }
+export type { ImageMode, ImagePlaceholerType, ImageProps, StyledImgProps }

--- a/src/components/base/Spinner/index.tsx
+++ b/src/components/base/Spinner/index.tsx
@@ -1,0 +1,10 @@
+import type { ReactElement } from 'react'
+import type { SpinnerProps } from './types'
+import { HashLoader } from 'react-spinners'
+import { PRIMARY } from '@constants'
+
+const Spinner = ({ loading = true, size = 50 }: SpinnerProps): ReactElement => (
+  <HashLoader color={PRIMARY} loading={loading} size={size} />
+)
+
+export default Spinner

--- a/src/components/base/Spinner/types.ts
+++ b/src/components/base/Spinner/types.ts
@@ -1,0 +1,6 @@
+interface SpinnerProps {
+  loading: boolean
+  size: string | number
+}
+
+export type { SpinnerProps }

--- a/src/data/models/types.ts
+++ b/src/data/models/types.ts
@@ -1,6 +1,7 @@
-interface IStory<PropsType> {
-  (): any
-  args?: PropsType
+import type { ReactElement } from 'react'
+interface IStory<Props> {
+  (args: Props): ReactElement
+  args?: Props
 }
 
 export type { IStory }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useClickAwayItem } from './useClickAwayItem'

--- a/src/hooks/useClickAwayItem.ts
+++ b/src/hooks/useClickAwayItem.ts
@@ -1,0 +1,37 @@
+import type { RefObject } from 'react'
+import { useEffect, useRef } from 'react'
+
+type onCloseType = () => void
+
+const useClickAwayItem = <RefType extends HTMLElement>(
+  onClose: onCloseType
+): RefObject<RefType> => {
+  const ref = useRef<RefType>(null)
+
+  const handleClickAway: EventListener = e => {
+    const target = e.target as HTMLElement
+    const dialogElement = ref.current
+
+    if (!dialogElement) {
+      return
+    }
+
+    !dialogElement.contains(target) && onClose()
+  }
+
+  useEffect(() => {
+    document.addEventListener('click', e => {
+      handleClickAway(e)
+    })
+
+    return () => {
+      document.removeEventListener('click', e => {
+        handleClickAway(e)
+      })
+    }
+  }, [])
+
+  return ref
+}
+
+export default useClickAwayItem

--- a/src/stories/components/base/Avatar.stories.tsx
+++ b/src/stories/components/base/Avatar.stories.tsx
@@ -1,6 +1,5 @@
 import Avatar from '@base/Avatar'
 import type { AvatarProps } from '@base/Avatar/types'
-import type { ReactElement } from 'react'
 import type { IStory } from '@models'
 
 export default {
@@ -21,16 +20,16 @@ export default {
   }
 }
 
-const Template = (args: AvatarProps): ReactElement => <Avatar {...args} />
+const Template: IStory<AvatarProps> = args => <Avatar {...args} />
 
-export const NoUser = Template.bind({}) as IStory<AvatarProps>
+export const NoUser = Template.bind({})
 NoUser.args = {
   src: '',
   width: 50,
   height: 50
 }
 
-export const User = Template.bind({}) as IStory<AvatarProps>
+export const User = Template.bind({})
 User.args = {
   src: 'https://picsum.photos/50',
   width: 50,

--- a/src/stories/components/base/Button.stories.tsx
+++ b/src/stories/components/base/Button.stories.tsx
@@ -1,4 +1,3 @@
-import type { ReactElement } from 'react'
 import { action } from '@storybook/addon-actions'
 import type { ButtonProps } from '@base/Button/types'
 import type { IStory } from '@data/models'
@@ -41,9 +40,9 @@ export default {
   }
 }
 
-const Template = (args: ButtonProps): ReactElement => <Button {...args} />
+const Template: IStory<ButtonProps> = args => <Button {...args} />
 
-export const PrimaryButton = Template.bind({}) as IStory<ButtonProps>
+export const PrimaryButton = Template.bind({})
 PrimaryButton.args = {
   children: '기본 버튼',
   type: 'button',
@@ -51,7 +50,7 @@ PrimaryButton.args = {
   onClick: action('기본 버튼 클릭!')
 }
 
-export const PostButton = Template.bind({}) as IStory<ButtonProps>
+export const PostButton = Template.bind({})
 PostButton.args = {
   children: '가격 제안하기 (0/2)',
   type: 'button',
@@ -59,7 +58,7 @@ PostButton.args = {
   onClick: action('게시글 상세 버튼 클릭!')
 }
 
-export const DisabledButton = Template.bind({}) as IStory<ButtonProps>
+export const DisabledButton = Template.bind({})
 DisabledButton.args = {
   children: '가격 제안하기 (0/0)',
   type: 'button',
@@ -67,7 +66,7 @@ DisabledButton.args = {
   onClick: action('오퍼 버튼 클릭!')
 }
 
-export const SearchButtonPrimary = Template.bind({}) as IStory<ButtonProps>
+export const SearchButtonPrimary = Template.bind({})
 SearchButtonPrimary.args = {
   children: '필터 적용',
   type: 'button',
@@ -78,7 +77,7 @@ SearchButtonPrimary.args = {
   onClick: action('필터 적용 버튼 클릭!')
 }
 
-export const SearchButtonLine = Template.bind({}) as IStory<ButtonProps>
+export const SearchButtonLine = Template.bind({})
 SearchButtonLine.args = {
   children: '초기화',
   type: 'button',
@@ -89,7 +88,7 @@ SearchButtonLine.args = {
   onClick: action('필터 초기화 버튼 클릭!')
 }
 
-export const ReviewButtonPrimary = Template.bind({}) as IStory<ButtonProps>
+export const ReviewButtonPrimary = Template.bind({})
 ReviewButtonPrimary.args = {
   children: '후기 보기',
   type: 'button',
@@ -101,7 +100,7 @@ ReviewButtonPrimary.args = {
   onClick: action('후기 보기 버튼 클릭!')
 }
 
-export const ReviewButtonLine = Template.bind({}) as IStory<ButtonProps>
+export const ReviewButtonLine = Template.bind({})
 ReviewButtonLine.args = {
   children: '후기 남기기',
   type: 'button',
@@ -113,7 +112,7 @@ ReviewButtonLine.args = {
   onClick: action('후기 남기기 버튼 클릭!')
 }
 
-export const ReviewButtonProduct = Template.bind({}) as IStory<ButtonProps>
+export const ReviewButtonProduct = Template.bind({})
 ReviewButtonProduct.args = {
   children: '구매상품 | 잠이 오는 보약 새 상품 >',
   type: 'button',
@@ -124,7 +123,7 @@ ReviewButtonProduct.args = {
   onClick: action('구매상품 보기 버튼 클릭!')
 }
 
-export const KakaoLoginButton = Template.bind({}) as IStory<ButtonProps>
+export const KakaoLoginButton = Template.bind({})
 KakaoLoginButton.args = {
   children: '카카오로 로그인',
   type: 'button',
@@ -132,7 +131,7 @@ KakaoLoginButton.args = {
   onClick: action('카카오로 로그인 버튼 클릭!')
 }
 
-export const MobileLoginButton = Template.bind({}) as IStory<ButtonProps>
+export const MobileLoginButton = Template.bind({})
 MobileLoginButton.args = {
   children: '로그인',
   type: 'button',
@@ -144,7 +143,7 @@ MobileLoginButton.args = {
   onClick: action('로그인 버튼 클릭!')
 }
 
-export const DuplicateButton = Template.bind({}) as IStory<ButtonProps>
+export const DuplicateButton = Template.bind({})
 DuplicateButton.args = {
   children: '중복검사',
   type: 'button',
@@ -156,7 +155,7 @@ DuplicateButton.args = {
   onClick: action('중복검사 버튼 클릭!')
 }
 
-export const MessageButtonPrimary = Template.bind({}) as IStory<ButtonProps>
+export const MessageButtonPrimary = Template.bind({})
 MessageButtonPrimary.args = {
   children: '전송',
   type: 'button',
@@ -167,7 +166,7 @@ MessageButtonPrimary.args = {
   onClick: action('메시지 전송 버튼 클릭!')
 }
 
-export const MessageButtonDisabled = Template.bind({}) as IStory<ButtonProps>
+export const MessageButtonDisabled = Template.bind({})
 MessageButtonDisabled.args = {
   children: '전송',
   type: 'button',

--- a/src/stories/components/base/Button.stories.tsx
+++ b/src/stories/components/base/Button.stories.tsx
@@ -1,0 +1,179 @@
+import type { ReactElement } from 'react'
+import { action } from '@storybook/addon-actions'
+import type { ButtonProps } from '@base/Button/types'
+import type { IStory } from '@data/models'
+import Button from '@base/Button'
+import { FONT_SIZE } from '@constants'
+
+export default {
+  title: 'Components/Base/Button',
+  component: Button,
+  argTypes: {
+    width: {
+      defaultValue: 215,
+      control: { type: 'number' }
+    },
+    height: {
+      defaultValue: 50,
+      control: { type: 'number' }
+    },
+    theme: {
+      defaultValue: 'primary',
+      options: [
+        'primary',
+        'disabled',
+        'kakao',
+        'line-primary',
+        'line-black',
+        'line-gray'
+      ],
+      control: { type: 'inline-radio' }
+    },
+    fontSize: {
+      defaultValue: 'SM',
+      options: [...Object.keys(FONT_SIZE)],
+      control: { type: 'inline-radio' }
+    },
+    strong: {
+      defaultValue: true,
+      control: { type: 'boolean' }
+    }
+  }
+}
+
+const Template = (args: ButtonProps): ReactElement => <Button {...args} />
+
+export const PrimaryButton = Template.bind({}) as IStory<ButtonProps>
+PrimaryButton.args = {
+  children: '기본 버튼',
+  type: 'button',
+  theme: 'primary',
+  onClick: action('기본 버튼 클릭!')
+}
+
+export const PostButton = Template.bind({}) as IStory<ButtonProps>
+PostButton.args = {
+  children: '가격 제안하기 (0/2)',
+  type: 'button',
+  theme: 'primary',
+  onClick: action('게시글 상세 버튼 클릭!')
+}
+
+export const DisabledButton = Template.bind({}) as IStory<ButtonProps>
+DisabledButton.args = {
+  children: '가격 제안하기 (0/0)',
+  type: 'button',
+  theme: 'disabled',
+  onClick: action('오퍼 버튼 클릭!')
+}
+
+export const SearchButtonPrimary = Template.bind({}) as IStory<ButtonProps>
+SearchButtonPrimary.args = {
+  children: '필터 적용',
+  type: 'button',
+  width: '150px',
+  height: '40px',
+  theme: 'primary',
+  fontSize: 'NORMAL',
+  onClick: action('필터 적용 버튼 클릭!')
+}
+
+export const SearchButtonLine = Template.bind({}) as IStory<ButtonProps>
+SearchButtonLine.args = {
+  children: '초기화',
+  type: 'button',
+  width: '150px',
+  height: '40px',
+  theme: 'line-primary',
+  fontSize: 'NORMAL',
+  onClick: action('필터 초기화 버튼 클릭!')
+}
+
+export const ReviewButtonPrimary = Template.bind({}) as IStory<ButtonProps>
+ReviewButtonPrimary.args = {
+  children: '후기 보기',
+  type: 'button',
+  width: '80px',
+  height: '30px',
+  theme: 'primary',
+  fontSize: 'XXS',
+  strong: false,
+  onClick: action('후기 보기 버튼 클릭!')
+}
+
+export const ReviewButtonLine = Template.bind({}) as IStory<ButtonProps>
+ReviewButtonLine.args = {
+  children: '후기 남기기',
+  type: 'button',
+  width: '80px',
+  height: '30px',
+  theme: 'line-primary',
+  fontSize: 'XXS',
+  strong: false,
+  onClick: action('후기 남기기 버튼 클릭!')
+}
+
+export const ReviewButtonProduct = Template.bind({}) as IStory<ButtonProps>
+ReviewButtonProduct.args = {
+  children: '구매상품 | 잠이 오는 보약 새 상품 >',
+  type: 'button',
+  height: '30px',
+  theme: 'line-gray',
+  fontSize: 'NORMAL',
+  strong: false,
+  onClick: action('구매상품 보기 버튼 클릭!')
+}
+
+export const KakaoLoginButton = Template.bind({}) as IStory<ButtonProps>
+KakaoLoginButton.args = {
+  children: '카카오로 로그인',
+  type: 'button',
+  theme: 'kakao',
+  onClick: action('카카오로 로그인 버튼 클릭!')
+}
+
+export const MobileLoginButton = Template.bind({}) as IStory<ButtonProps>
+MobileLoginButton.args = {
+  children: '로그인',
+  type: 'button',
+  width: '55px',
+  height: '30px',
+  theme: 'line-black',
+  fontSize: 'XXS',
+  strong: false,
+  onClick: action('로그인 버튼 클릭!')
+}
+
+export const DuplicateButton = Template.bind({}) as IStory<ButtonProps>
+DuplicateButton.args = {
+  children: '중복검사',
+  type: 'button',
+  width: '70px',
+  height: '40px',
+  theme: 'line-gray',
+  fontSize: 'XXXS',
+  strong: false,
+  onClick: action('중복검사 버튼 클릭!')
+}
+
+export const MessageButtonPrimary = Template.bind({}) as IStory<ButtonProps>
+MessageButtonPrimary.args = {
+  children: '전송',
+  type: 'button',
+  width: '50px',
+  height: '25px',
+  theme: 'primary',
+  fontSize: 'XXXS',
+  onClick: action('메시지 전송 버튼 클릭!')
+}
+
+export const MessageButtonDisabled = Template.bind({}) as IStory<ButtonProps>
+MessageButtonDisabled.args = {
+  children: '전송',
+  type: 'button',
+  width: '50px',
+  height: '25px',
+  theme: 'disabled',
+  fontSize: 'XXXS',
+  onClick: action('메시지 전송 버튼 클릭!')
+}

--- a/src/stories/components/base/Dialog.stories.tsx
+++ b/src/stories/components/base/Dialog.stories.tsx
@@ -46,6 +46,7 @@ const Template: IStory<DialogProps<HTMLUListElement>> = args => {
 
 export const HeaderDialog = Template.bind({})
 HeaderDialog.args = {
+  dialogRef: null,
   visible: false,
   dialogItemList: [
     {
@@ -73,6 +74,7 @@ HeaderDialog.args = {
 
 export const ProductDialog = Template.bind({})
 ProductDialog.args = {
+  dialogRef: null,
   visible: false,
   dialogItemList: [
     {

--- a/src/stories/components/base/Dialog.stories.tsx
+++ b/src/stories/components/base/Dialog.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions'
 import Button from '@base/Button'
 import Dialog from '@base/Dialog'
 import type { DialogProps } from '@base/Dialog/types'
@@ -43,9 +44,9 @@ const Template: IStory<DialogProps<HTMLUListElement>> = args => {
   )
 }
 
-export const HeaderDialog: IStory<DialogProps<HTMLUListElement>> =
-  Template.bind({})
+export const HeaderDialog = Template.bind({})
 HeaderDialog.args = {
+  visible: false,
   dialogItemList: [
     {
       href: 'profile',
@@ -65,33 +66,22 @@ HeaderDialog.args = {
     },
     {
       text: '로그아웃',
-      onClick: (e): void => {
-        e.preventDefault()
-        console.log('로그아웃')
-      }
+      onClick: action('로그아웃!')
     }
-  ],
-  visible: false
+  ]
 }
 
-export const ProductDialog: IStory<DialogProps<HTMLUListElement>> =
-  Template.bind({})
+export const ProductDialog = Template.bind({})
 ProductDialog.args = {
+  visible: false,
   dialogItemList: [
     {
       text: '게시글 수정',
-      onClick: (e): void => {
-        e.preventDefault()
-        console.log('게시글 수정')
-      }
+      onClick: action('게시글 수정!')
     },
     {
       text: '게시글 삭제',
-      onClick: (e): void => {
-        e.preventDefault()
-        console.log('게시글 삭제')
-      }
+      onClick: action('게시글 삭제!')
     }
-  ],
-  visible: false
+  ]
 }

--- a/src/stories/components/base/Dialog.stories.tsx
+++ b/src/stories/components/base/Dialog.stories.tsx
@@ -1,0 +1,97 @@
+import Button from '@base/Button'
+import Dialog from '@base/Dialog'
+import type { DialogProps } from '@base/Dialog/types'
+import type { IStory } from '@data/models'
+import { useClickAwayItem } from '@hooks'
+import type { MouseEventHandler } from 'react'
+import { useState } from 'react'
+
+export default {
+  title: 'Components/Base/Dialog',
+  component: Dialog,
+  argTypes: {
+    width: {
+      defaultValue: 90,
+      control: { type: 'number' }
+    }
+  }
+}
+
+const Template: IStory<DialogProps<HTMLUListElement>> = args => {
+  const [visible, setVisible] = useState(args.visible)
+  const dialogRef = useClickAwayItem<HTMLUListElement>(() => {
+    setVisible(false)
+  })
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = e => {
+    e.stopPropagation()
+    setVisible(!visible)
+  }
+
+  return (
+    <>
+      <Button
+        height="40px"
+        theme="line-black"
+        type="button"
+        width="80px"
+        onClick={handleClick}>
+        Dialog
+      </Button>
+      <Dialog {...args} dialogRef={dialogRef} visible={visible} />
+    </>
+  )
+}
+
+export const HeaderDialog: IStory<DialogProps<HTMLUListElement>> =
+  Template.bind({})
+HeaderDialog.args = {
+  dialogItemList: [
+    {
+      href: 'profile',
+      text: '내 프로필',
+      onClick: (e): void => {
+        e.preventDefault()
+        console.log('내 프로필')
+      }
+    },
+    {
+      href: 'messages',
+      text: '내 쪽지함',
+      onClick: (e): void => {
+        e.preventDefault()
+        console.log('내 쪽지함')
+      }
+    },
+    {
+      text: '로그아웃',
+      onClick: (e): void => {
+        e.preventDefault()
+        console.log('로그아웃')
+      }
+    }
+  ],
+  visible: false
+}
+
+export const ProductDialog: IStory<DialogProps<HTMLUListElement>> =
+  Template.bind({})
+ProductDialog.args = {
+  dialogItemList: [
+    {
+      text: '게시글 수정',
+      onClick: (e): void => {
+        e.preventDefault()
+        console.log('게시글 수정')
+      }
+    },
+    {
+      text: '게시글 삭제',
+      onClick: (e): void => {
+        e.preventDefault()
+        console.log('게시글 삭제')
+      }
+    }
+  ],
+  visible: false
+}

--- a/src/stories/components/base/Image.stories.tsx
+++ b/src/stories/components/base/Image.stories.tsx
@@ -1,4 +1,3 @@
-import type { ReactElement } from 'react'
 import Image from '@base/Image'
 import type { ImageProps } from '@base/Image/types'
 import type { IStory } from '@models'
@@ -41,7 +40,7 @@ export default {
   }
 }
 
-const Template = (args: ImageProps): ReactElement => (
+const Template: IStory<ImageProps> = args => (
   <>
     {Array.from({ length: 10 }).map((_, idx) => (
       <Image key={idx} {...args} />
@@ -49,7 +48,7 @@ const Template = (args: ImageProps): ReactElement => (
   </>
 )
 
-export const User = Template.bind({}) as IStory<ImageProps>
+export const User = Template.bind({})
 User.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',
@@ -59,7 +58,7 @@ User.args = {
   block: true
 }
 
-export const Product = Template.bind({}) as IStory<ImageProps>
+export const Product = Template.bind({})
 Product.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',
@@ -69,7 +68,7 @@ Product.args = {
   block: true
 }
 
-export const Square = Template.bind({}) as IStory<ImageProps>
+export const Square = Template.bind({})
 Square.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',
@@ -79,7 +78,7 @@ Square.args = {
   block: true
 }
 
-export const RectangleW = Template.bind({}) as IStory<ImageProps>
+export const RectangleW = Template.bind({})
 RectangleW.args = {
   src: 'https://picsum.photos/400',
   mode: 'cover',
@@ -89,7 +88,7 @@ RectangleW.args = {
   block: true
 }
 
-export const RectangleH = Template.bind({}) as IStory<ImageProps>
+export const RectangleH = Template.bind({})
 RectangleH.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',

--- a/src/stories/components/base/Image.stories.tsx
+++ b/src/stories/components/base/Image.stories.tsx
@@ -1,13 +1,6 @@
 import type { ReactElement } from 'react'
 import Image from '@base/Image'
 import type { ImageProps } from '@base/Image/types'
-import {
-  NO_IMAGE_USER,
-  NO_IMAGE_SQUARE,
-  NO_IMAGE_RECTANGLE_H,
-  NO_IMAGE_RECTANGLE_W,
-  NO_IMAGE_PRODUCT
-} from '@constants'
 import type { IStory } from '@models'
 
 export default {
@@ -40,7 +33,7 @@ export default {
       options: ['cover', 'fill', 'contain'],
       control: { type: 'inline-radio' }
     },
-    type: {
+    placeholder: {
       defaultValue: 'product',
       options: ['user', 'product', 'square', 'rectangleW', 'rectangleH'],
       control: { type: 'inline-radio' }
@@ -60,53 +53,48 @@ export const User = Template.bind({}) as IStory<ImageProps>
 User.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',
-  type: 'user',
+  placeholder: 'user',
   width: 200,
   height: 200,
-  block: true,
-  placeholder: NO_IMAGE_USER
+  block: true
 }
 
 export const Product = Template.bind({}) as IStory<ImageProps>
 Product.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',
-  type: 'product',
+  placeholder: 'product',
   width: 235,
   height: 280,
-  block: true,
-  placeholder: NO_IMAGE_PRODUCT
+  block: true
 }
 
 export const Square = Template.bind({}) as IStory<ImageProps>
 Square.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',
-  type: 'square',
+  placeholder: 'square',
   width: 200,
   height: 200,
-  block: true,
-  placeholder: NO_IMAGE_SQUARE
+  block: true
 }
 
 export const RectangleW = Template.bind({}) as IStory<ImageProps>
 RectangleW.args = {
   src: 'https://picsum.photos/400',
   mode: 'cover',
-  type: 'rectangleW',
+  placeholder: 'rectangleW',
   width: 400,
   height: 200,
-  block: true,
-  placeholder: NO_IMAGE_RECTANGLE_W
+  block: true
 }
 
 export const RectangleH = Template.bind({}) as IStory<ImageProps>
 RectangleH.args = {
   src: 'https://picsum.photos/200',
   mode: 'cover',
-  type: 'rectangleH',
+  placeholder: 'rectangleH',
   width: 200,
   height: 400,
-  block: true,
-  placeholder: NO_IMAGE_RECTANGLE_H
+  block: true
 }

--- a/src/stories/components/base/Spinner.stories.tsx
+++ b/src/stories/components/base/Spinner.stories.tsx
@@ -1,0 +1,31 @@
+import Spinner from '@base/Spinner'
+import type { SpinnerProps } from '@base/Spinner/types'
+import type { IStory } from '@data/models'
+import styled from '@emotion/styled'
+
+export default {
+  title: 'Components/Base/Spinner',
+  component: Spinner,
+  argTypes: {
+    loading: {
+      defaultValue: true,
+      control: { type: 'boolean' }
+    },
+    size: {
+      defaultValue: 50,
+      control: { type: 'number' }
+    }
+  }
+}
+
+const StyledSpinnerWrapper = styled.div`
+  display: flex;
+  padding-top: 30px;
+  padding-left: 30px;
+`
+
+export const Primary: IStory<SpinnerProps> = args => (
+  <StyledSpinnerWrapper>
+    <Spinner {...args} />
+  </StyledSpinnerWrapper>
+)

--- a/src/stories/hooks/useClickAwayItem.stories.tsx
+++ b/src/stories/hooks/useClickAwayItem.stories.tsx
@@ -1,0 +1,45 @@
+import Button from '@base/Button'
+import styled from '@emotion/styled'
+import { useClickAwayItem } from '@hooks'
+import type { IStory } from '@models'
+import type { MouseEventHandler } from 'react'
+import { useState } from 'react'
+
+export default {
+  title: 'Hooks/useClickAwayItem'
+}
+
+const StyledDiv = styled.div`
+  position: absolute;
+  top: 100px;
+  width: 150px;
+  height: 150px;
+  border: 1px solid black;
+  background-color: tomato;
+  color: white;
+`
+
+interface IStoryProps {
+  visible: boolean
+}
+
+export const UseClickAwayItem: IStory<IStoryProps> = args => {
+  const [visible, setVisible] = useState(args.visible)
+  const divRef = useClickAwayItem<HTMLDivElement>(() => {
+    setVisible(false)
+  })
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = e => {
+    e.stopPropagation()
+    setVisible(!visible)
+  }
+
+  return (
+    <>
+      <Button theme="line-black" type="button" onClick={handleClick}>
+        clickAway Item
+      </Button>
+      {visible && <StyledDiv ref={divRef}>hook 테스트</StyledDiv>}
+    </>
+  )
+}


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #10

## 📚 내용 설명
베이스 컴포넌트에 대한 props를 재정의하고 디자인 시스템을 개선하는 내용의 작업입니다.

### Button Component
**Button 컴포넌트 필수 props**
- **`type`** : 'button' | 'submit'
- **`theme`** :  'primary' | 'disabled' | 'kakao' | 'line-primary' | 'line-black' | 'line-gray'

**Button 컴포넌트 선택 props**
- **`width`**
- **`height`**
- **`fontSize`**
- **`strong`**

**Button 컴포넌트 설명**
- **사용자가 필수 prop외 다른 props들을 명시하지 않는 경우, primary가 기본 ui로 적용됩니다.**
  (storybook에서 확인해보실 수 있습니다.)
- 공통적인 버튼의 스타일의 경우, 개별 속성 내 props를 활용하여 작업하였습니다.
- `theme`를 활용한 스타일의 경우, `applyThemeStyle` 함수를 거치게 작업하였습니다.
  - 받을 수 있는 `theme`의 타입은 `ButtonTheme` 타입만 받을 수 있습니다.
  - `theme`에 해당하는 `style`이 `string` 형태로 반환됩니다.

### Spinner Component
**Spinner 컴포넌트 필수 props**
- **`loading`** : boolean
- **`size`** : string | number

**Spinner 컴포넌트 설명**
- `loading`을 통해 display 여부를 결정합니다.
- `size`를 통해 1:1 비율로 스피너의 크기를 결정합니다.

### Dialog Component
**Dialog 컴포넌트 필수 props**
- **`visible`** : boolean
- **`dialogRef`** : RefObject\<RefType>
- **`dialogItemList`** : IdialogItem[]
  ```
  interface IdialogItem {
    text: string
    href?: string
    onClick?(e?: any): void
   }
  ```

**Dialog 컴포넌트 선택 props**
- **`width`**: string | number

**Dialog 컴포넌트 설명**
- 버튼 클릭 시, 등장하는 dialog 형태의 list입니다.
- `useClickAway hook`을 이용하여 얻은 `ref`와 `useState hook`을 이용하여 만든 `visible(state)`를 dialog에 넣어주어야 합니다.
- `dialogItem` 속성에서 `href`가 있는 경우. `Link` 태그를, 없는 경우에는 일반 `span`태그로 반환됩니다.
- **조건**
  - 요소 외부 클릭 시, 요소가 사라져야 함
  - trigger역할인 button 클릭 시, 요소가 toggle되어야 함
  - `href`가 있는 경우, `Link` 태그로 감싼 `a`태그로 동작되어야 함

### useClickAwayItem Hook
**useClickAwayItem Hook 설명**
- 내부에서 `ref`를 생성하여 해당 요소의 이벤트인지 체크해주고 해당 요소 외부에서 발생한 이벤트인 경우, `onClose`를 해주는 hook입니다.
- `onClose`될 때, 실행이 되어야 하는 함수를 인자로 받으며 `ref`를 반환합니다.
- hook 내부에서 생성된 `ref`를 요소에 넣어주는 것으로 동작합니다.
  **(별도의 visible state 관리는 되어 있어야 합니다.)**

**useClickAwayItem Hook 사용 방법**
- `useClickAwayItem Hook`에 `onClose` 함수를 전달하여 호출
  - **요소의 `ref` 생성 시, 제네릭 타입이 필요함으로 요소의 `element` 타입을 넣어준다.**
- hook 호출 시, refurn 받은 `ref`를 요소의 `ref`로 넣어준다.

## ⏳ 실행 화면

### Button Component
![image](https://user-images.githubusercontent.com/47546413/152191147-d136bdb0-7bc1-47fb-8bb1-223f46968530.png)
![image](https://user-images.githubusercontent.com/47546413/152193077-455cce8f-a19b-4fb4-90a9-e500e091a741.png)

### Spinner Component
![image](https://user-images.githubusercontent.com/47546413/152667559-e81010cb-b439-410f-b0f7-afae1fa4745e.png)

### Dialog Component
![image](https://user-images.githubusercontent.com/47546413/152667519-9a845458-aec4-47e2-8138-218d1d01b1c8.png)
![image](https://user-images.githubusercontent.com/47546413/152667529-fc612fc6-e04d-429d-9705-2df8205c73fd.png)

### useClickAwayItem Hook
![image](https://user-images.githubusercontent.com/47546413/152667541-9e6182b1-a4c7-4a2d-ad21-78c55dd4bee3.png)

## ⛳ 요구 사항
- [x]  Button Component
- [x]  Dialog Component
- [x] useClickAwayItem Hook
- [x]  Spinner Component

## 🛠 피드백 반영 사항
- **Image, Avatar**
  - [x] 변경된 이미지 경로 반영
- **Image**
  - [x] onErrorType, placeholder 중복 제거, placeholder로 통일
- **Button**
  - [x] width, height, theme를 설정하여 버튼의 ui를 유동적으로 변경할 수 있게 개선
  - [x] `covertToStyle(theme)` => `applyThemeStyle(theme)` 로 함수명 개선
- **Dialog**
  - [ ] `margin`이용대신 flex로 gap 속성 부여하기